### PR TITLE
web コンテナが dbコンテナより先に起動してしまうエラーの応急処置

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,6 +3,8 @@ version: '3.8'
 services:
   web:
     build: .
+    command: >
+      sh -c "sleep 5 && python manage.py runserver_plus 0.0.0.0:8000"
     env_file: .env
     container_name: django_app
     ports:


### PR DESCRIPTION
git clone 後に docker-compose を立ち上げた際、「Hello world」が表示されないエラーが発生していたため、その修正対応になります。

原因は、web コンテナが db コンテナよりも先に起動してしまい、Django が MySQL に接続できなかったことによるものです。

暫定対応として、web サービスに sleep を挟み、起動を少し遅らせるようにしています。
将来的には .wait-for-it.sh のようなスクリプトを導入し、より確実に依存関係を制御する方法に置き換えるのが望ましいと考えています。

ご確認よろしくお願いいたします。