### PR TITLE
CustomUserとStoreモデルの定義

### DIFF
--- a/account/models.py
+++ b/account/models.py
@@ -1,3 +1,41 @@
+import uuid
 from django.db import models
+from django.contrib.auth.models import AbstractUser
 
-# Create your models here.
+
+class CustomUser(AbstractUser):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    email = models.EmailField(unique=True, null=False, blank=False)
+    updated_at = models.DateTimeField(auto_now=True, null=False)
+
+    USERNAME_FIELD = 'email'
+    REQUIRED_FIELDS = ['username']
+
+    class Meta:
+        db_table = 'users'
+        verbose_name = 'User'
+        verbose_name_plural = 'Users'
+
+    def __str__(self):
+        return self.email
+
+
+class Store(models.Model):
+    user = models.ForeignKey(
+        'CustomUser',
+        on_delete=models.CASCADE,
+        related_name='stores',
+        db_column='user_id',
+    )
+
+    store_name = models.CharField(max_length=255, null=False, blank=False)
+    created_at = models.DateTimeField(auto_now_add=True, null=False)
+    updated_at = models.DateTimeField(auto_now=True, null=False)
+
+    class Meta:
+        db_table = 'stores'
+        verbose_name = 'Store'
+        verbose_name_plural = 'Stores'
+
+    def __str__(self):
+        return self.store_name

--- a/config/settings.py
+++ b/config/settings.py
@@ -46,16 +46,18 @@ if DEBUG:
 
 INSTALLED_APPS = [
     'django.contrib.admin',
+    'account',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'account',
     'coupon',
     'debug_toolbar',
     'django_extensions',
 ]
+
+AUTH_USER_MODEL = 'account.CustomUser'
 
 MIDDLEWARE = [ 
     'debug_toolbar.middleware.DebugToolbarMiddleware',


### PR DESCRIPTION
users・storesテーブルのモデル定義を実装しました。
usersについて、ER図ではcreated_atが定義されていますが、AbstractUserのデフォルト機能としてdate_joinedがあり、created_atと同義のためこちらを採用しています。
その他、データ型についてはAbstractUserのデフォルトの値を優先し、ER図の方の修正を依頼する予定です。
settings.pyにAUTH_USER_MODELを設定し、CustomUserを参照するようにしています。
デバック済みです。
ご確認よろしくお願い致します。